### PR TITLE
SingleLiveEvent in navigation

### DIFF
--- a/common-navigate/src/main/java/ru/practicum/android/diploma/navigate/observable/SingleLiveEvent.kt
+++ b/common-navigate/src/main/java/ru/practicum/android/diploma/navigate/observable/SingleLiveEvent.kt
@@ -20,6 +20,4 @@ class SingleLiveEvent<T> : MutableLiveData<T>() {
         pending.set(true)
         super.setValue(t)
     }
-
-
 }

--- a/common-navigate/src/main/java/ru/practicum/android/diploma/navigate/observable/SingleLiveEvent.kt
+++ b/common-navigate/src/main/java/ru/practicum/android/diploma/navigate/observable/SingleLiveEvent.kt
@@ -1,5 +1,6 @@
 package ru.practicum.android.diploma.navigate.observable
 
+import androidx.annotation.MainThread
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
@@ -8,6 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class SingleLiveEvent<T> : MutableLiveData<T>() {
     private val pending = AtomicBoolean(false)
 
+    @MainThread
     override fun observe(owner: LifecycleOwner, observer: Observer<in T>) {
         super.observe(owner) { t ->
             if (pending.compareAndSet(true, false)) {
@@ -16,6 +18,7 @@ class SingleLiveEvent<T> : MutableLiveData<T>() {
         }
     }
 
+    @MainThread
     override fun setValue(t: T?) {
         pending.set(true)
         super.setValue(t)

--- a/common-navigate/src/main/java/ru/practicum/android/diploma/navigate/observable/SingleLiveEvent.kt
+++ b/common-navigate/src/main/java/ru/practicum/android/diploma/navigate/observable/SingleLiveEvent.kt
@@ -1,0 +1,25 @@
+package ru.practicum.android.diploma.navigate.observable
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.atomic.AtomicBoolean
+
+class SingleLiveEvent<T> : MutableLiveData<T>() {
+    private val pending = AtomicBoolean(false)
+
+    override fun observe(owner: LifecycleOwner, observer: Observer<in T>) {
+        super.observe(owner) { t ->
+            if (pending.compareAndSet(true, false)) {
+                observer.onChanged(t)
+            }
+        }
+    }
+
+    override fun setValue(t: T?) {
+        pending.set(true)
+        super.setValue(t)
+    }
+
+
+}

--- a/common-navigate/src/main/java/ru/practicum/android/diploma/navigate/observable/impl/NavigateImpl.kt
+++ b/common-navigate/src/main/java/ru/practicum/android/diploma/navigate/observable/impl/NavigateImpl.kt
@@ -1,13 +1,13 @@
 package ru.practicum.android.diploma.navigate.observable.impl
 
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import ru.practicum.android.diploma.navigate.observable.Navigate
+import ru.practicum.android.diploma.navigate.observable.SingleLiveEvent
 
 internal class NavigateImpl<T> : Navigate<T> {
 
-    private val _navigateEventState = MutableLiveData<T>()
+    private val _navigateEventState = SingleLiveEvent<T>()
 
     override fun observeNavigateEventState(owner: LifecycleOwner, observer: Observer<T>) {
         _navigateEventState.observe(owner, observer)


### PR DESCRIPTION
Добавлено использование SingleLiveEvent - подкласса LiveData, который позволяет обрабатывать события однократно. SingleLiveEvent позволяет обеспечить отправку событий только один раз и избежать проблем с дублированием событий, обрабатываемых наблюдателями.