### PR TITLE
Change LRUCache to ConcurrentHashMap

### DIFF
--- a/data-cache/src/main/java/ru/practicum/android/diploma/cache/api/impl/MemoryCacheImpl.kt
+++ b/data-cache/src/main/java/ru/practicum/android/diploma/cache/api/impl/MemoryCacheImpl.kt
@@ -1,22 +1,14 @@
 package ru.practicum.android.diploma.cache.api.impl
 
-import android.util.LruCache
 import ru.practicum.android.diploma.cache.api.MemoryCache
 import ru.practicum.android.diploma.cache.dto.CountryCache
+import java.util.concurrent.ConcurrentHashMap
 
 private const val CACHE_KEY = "cache_key"
-private const val ONE_MEGABYTE = 1024
-private const val ONE_EIGHTH_SECTION = 8
 
 class MemoryCacheImpl : MemoryCache {
 
-    private val cache: LruCache<String, List<CountryCache>>
-
-    init {
-        val maxMemory = (Runtime.getRuntime().maxMemory() / ONE_MEGABYTE).toInt()
-        val cacheSize = maxMemory / ONE_EIGHTH_SECTION
-        cache = LruCache(cacheSize)
-    }
+    private val cache: ConcurrentHashMap<String, List<CountryCache>> = ConcurrentHashMap()
 
     override fun putCountries(countriesCache: List<CountryCache>) {
         if (getCountries() == null) {

--- a/data-cache/src/main/java/ru/practicum/android/diploma/cache/api/impl/MemoryCacheImpl.kt
+++ b/data-cache/src/main/java/ru/practicum/android/diploma/cache/api/impl/MemoryCacheImpl.kt
@@ -11,8 +11,10 @@ class MemoryCacheImpl : MemoryCache {
     private val cache: ConcurrentHashMap<String, List<CountryCache>> = ConcurrentHashMap()
 
     override fun putCountries(countriesCache: List<CountryCache>) {
-        if (getCountries() == null) {
-            cache.put(CACHE_KEY, countriesCache)
+        synchronized(this) {
+            if (getCountries() == null) {
+                cache.put(CACHE_KEY, countriesCache)
+            }
         }
     }
 
@@ -21,6 +23,8 @@ class MemoryCacheImpl : MemoryCache {
     }
 
     override fun clearCache() {
-        cache.remove(CACHE_KEY)
+        synchronized(this) {
+            cache.remove(CACHE_KEY)
+        }
     }
 }

--- a/data-cache/src/main/java/ru/practicum/android/diploma/cache/api/impl/MemoryCacheImpl.kt
+++ b/data-cache/src/main/java/ru/practicum/android/diploma/cache/api/impl/MemoryCacheImpl.kt
@@ -11,10 +11,8 @@ class MemoryCacheImpl : MemoryCache {
     private val cache: ConcurrentHashMap<String, List<CountryCache>> = ConcurrentHashMap()
 
     override fun putCountries(countriesCache: List<CountryCache>) {
-        synchronized(this) {
-            if (getCountries() == null) {
-                cache.put(CACHE_KEY, countriesCache)
-            }
+        if (getCountries() == null) {
+            cache.put(CACHE_KEY, countriesCache)
         }
     }
 
@@ -23,8 +21,6 @@ class MemoryCacheImpl : MemoryCache {
     }
 
     override fun clearCache() {
-        synchronized(this) {
-            cache.remove(CACHE_KEY)
-        }
+        cache.remove(CACHE_KEY)
     }
 }


### PR DESCRIPTION
Изменила LRUCache на ConcurrentHashMap, которая имеет встроенную синхронизацию и обеспечивает потокобезопасность, убрала выделение памяти под нее.